### PR TITLE
Allow keymaps only to be turned off

### DIFF
--- a/plugin/sonicpi.vim
+++ b/plugin/sonicpi.vim
@@ -11,12 +11,18 @@ if !exists('g:sonicpi_enabled')
   let g:sonicpi_enabled = 1
 endif
 
+if !exists('g:sonicpi_keymaps_enabled')
+  let g:sonicpi_keymaps_enabled = 1
+endif
+
 " Contextual initialization modelled after tpope's vim-sonicpi
 function! sonicpi#detect()
   " Test if Sonic Pi is available. (Pending a PR for sonic-pi-cli.)
   let s:activep = system(g:sonicpi_command.' stop 2>/dev/null && echo -n $?')
   if s:activep == 0 && expand(&filetype) == 'ruby' && g:sonicpi_enabled
-    call s:load_keymaps()
+    if g:sonicpi_keymaps_enabled
+      call s:load_keymaps()
+    endif
     call s:load_autocomplete()
     call s:load_syntax()
   endif


### PR DESCRIPTION
This is awesome. Thanks for putting it together!

As a user, I want to disable the standard keymaps so I can created my own, but to keep the autocomplete and syntax. This lets me do that.
