### PR TITLE
Adding support for sonic-pi-tool

### DIFF
--- a/plugin/sonicpi.vim
+++ b/plugin/sonicpi.vim
@@ -53,7 +53,12 @@ function! s:load_syntax()
 endfunction
 
 function! s:SonicPiSendBuffer()
-  execute "silent w !" . g:sonicpi_command
+  " Extend compatibility to sonic-pi-tool
+  if g:sonicpi_command == "sonic-pi-tool"
+    execute "silent w ! xargs -0 " . g:sonicpi_command . " eval "
+  else
+    execute "silent w !" . g:sonicpi_command
+  endif
 endfunction
 
 function! s:SonicPiStop()


### PR DESCRIPTION
`sonicpi.vim` contains the option `g:sonicpi_command` to allow other Sonic Pi server interfaces than [`sonic-pi-cli`](https://github.com/Widdershin/sonic-pi-cli/). The main alternative used to be [`sonic-pi-pipe`](https://github.com/lpil/sonic-pi-tool/tree/master/old), however, this is now defunct and has been replaced by [`sonic-pi-tool`](https://github.com/lpil/sonic-pi-tool) which provides a number of benefits over the options mentioned above, including support for logging and recording in a single unified tool.

However, `sonic-pi-tool` can't accept Sonic Pi code on `stdin`, so this vim plugin no longer works with that tool. This patch makes minor changes to `SonicPiSendBuffer()` to allow for detection of `sonic-pi-tool` and then passes input to it in a way it can handle.