### PR TITLE
Add configuration options for g:sonicpi_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ As an example, to use
 `.vimrc` settings would work:
 
 ```vim
-let g:sonicpi_command = "sonic-pi-tool"
+let g:sonicpi_command = 'sonic-pi-tool'
 let g:sonicpi_send = 'eval-stdin'
 let g:sonicpi_stop = 'stop'
 let g:vim_redraw = 1

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ let g:vim_redraw = 1
 
 * [sonic-pi-cli](https://github.com/Widdershin/sonic-pi-cli/). The default.
 
-* [sonic-pi-tool](https://github.com/lpil/sonic-pi-tool). Written in Go, and more responsive than sonic-pi-cli.
+* [sonic-pi-tool](https://github.com/lpil/sonic-pi-tool). Written in Rust, and more responsive than sonic-pi-cli.
 
 * [sonic-pi-pipe](https://github.com/lpil/sonic-pi-tool/tree/master/old). An
-older version of `sonic-pi-tool` with less functionality.
+older version of `sonic-pi-tool` with less functionality written in Go.
 
 ### TODO
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,33 @@ Whenever Sonic Pi is running, and you haven't disabled the `g:sonicpi_enabled` f
 `g:sonicpi_command` can be used to configure what tool is used to send the
 code to Sonic Pi. The default is `sonic_pi`.
 
+`g:sonicpi_send` and `g:sonicpi_stop` can be used to adjust the arguments sent
+to `g:sonicpi_command`. The default values are `g:sonicpi_send = ''` and
+`g:sonicpi_stop = 'stop'`.
+
+`g:vim_redraw`, if true (such as by setting it to `1`), will redraw the screen
+after the stop command instead of waiting for output. Its default value is
+`0`.
+
+As an example, to use
+[`sonic-pi-tool`](https://github.com/lpil/sonic-pi-tool/), the following
+`.vimrc` settings would work:
+
+```vim
+let g:sonicpi_command = "sonic-pi-tool"
+let g:sonicpi_send = 'eval-stdin'
+let g:sonicpi_stop = 'stop'
+let g:vim_redraw = 1
+```
 
 ## Sonic Pi interfacing tools
 
 * [sonic-pi-cli](https://github.com/Widdershin/sonic-pi-cli/). The default.
 
-* [sonic-pi-pipe](https://github.com/lpil/sonic-pi-tools). Written in Go, and more responsive than sonic-pi-cli.
+* [sonic-pi-tool](https://github.com/lpil/sonic-pi-tool). Written in Go, and more responsive than sonic-pi-cli.
 
+* [sonic-pi-pipe](https://github.com/lpil/sonic-pi-tool/tree/master/old). An
+older version of `sonic-pi-tool` with less functionality.
 
 ### TODO
 

--- a/plugin/sonicpi.vim
+++ b/plugin/sonicpi.vim
@@ -7,6 +7,18 @@ if !exists('g:sonicpi_command')
   let g:sonicpi_command = 'sonic_pi'
 endif
 
+if !exists('g:sonicpi_send')
+  let g:sonicpi_send = ''
+endif
+
+if !exists('g:sonicpi_stop')
+  let g:sonicpi_stop = 'stop'
+endif
+
+if !exists('g:vim_redraw')
+  let g:vim_redraw = 0
+endif
+
 if !exists('g:sonicpi_enabled')
   let g:sonicpi_enabled = 1
 endif
@@ -53,11 +65,14 @@ function! s:load_syntax()
 endfunction
 
 function! s:SonicPiSendBuffer()
-  execute "silent w !" . g:sonicpi_command
+  execute "silent w !" . g:sonicpi_command . " " . g:sonicpi_send
 endfunction
 
 function! s:SonicPiStop()
-  execute "silent !" . g:sonicpi_command . " stop"
+  execute "silent !" . g:sonicpi_command . " " . g:sonicpi_stop
+  if g:vim_redraw
+    execute ":redraw!"
+  endif
 endfunction
 
 " Export public API


### PR DESCRIPTION
Per the discussion on [issue 18](18) and at [`sonic-pi-tool`](https://github.com/lpil/sonic-pi-tool/issues/24), this patch extends `sonicpi.vim` to have 3 new options:

1. `g:sonicpi_send`, which provides an argument to `g:sonicpi_command` when `SonicPiSendBuffer()` is called
2. `g:sonicpi_stop`, which provides an argument to `g:sonicpi_command` when `SonicPiStop()` is called
3. `g:vim_redraw`, which triggers the screen to be redrawn after `SonicPiStop()` is called instead of waiting for the command's output

This allows for use of programs other than `sonic_pi` which require arguments to correctly process data sent on `stdin` or to stop the server. The patch additionally updates the documentation accordingly.