### PR TITLE
Add range support in visual mode for SonicPiSendBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The sonicpi vim plugin requires the following:
 
 The plugin enables itself when Sonic Pi is running and the Ruby filetype is initiated (`let g:sonicpi_enabled = 0` to disable), and provides the following features:
 
-* `<leader>r` - send buffer to sonicpi
+* `<leader>r` - send current buffer or visual mode line selection to sonicpi
 
 * `<leader>S` - send stop message to sonicpi
 

--- a/plugin/sonicpi.vim
+++ b/plugin/sonicpi.vim
@@ -64,8 +64,8 @@ function! s:load_syntax()
   runtime! syntax/sonicpi.vim
 endfunction
 
-function! s:SonicPiSendBuffer()
-  execute "silent w !" . g:sonicpi_command . " " . g:sonicpi_send
+function! s:SonicPiSendBuffer() range
+  execute "silent " . a:firstline . "," . a:lastline . " w !" . g:sonicpi_command . " " . g:sonicpi_send
 endfunction
 
 function! s:SonicPiStop()
@@ -76,11 +76,12 @@ function! s:SonicPiStop()
 endfunction
 
 " Export public API
-command! -nargs=0 SonicPiSendBuffer call s:SonicPiSendBuffer()
+command! -nargs=0 -range=% SonicPiSendBuffer let view = winsaveview() | <line1>,<line2>call s:SonicPiSendBuffer() | call winrestview(view)
 command! -nargs=0 SonicPiStop call s:SonicPiStop()
 
 " Set keymaps in Normal mode
 function! s:load_keymaps()
   nnoremap <leader>r :SonicPiSendBuffer<CR>
+  vnoremap <leader>r :SonicPiSendBuffer<CR>
   nnoremap <leader>S :SonicPiStop<CR>
 endfunction


### PR DESCRIPTION
Closes #21 

I've backported the ranged send feature from lilyinstarlight/vim-sonic-pi@d39d286 that allows mappings in visual mode to send the selections lines to the server. It will only send whole lines so if less than a whole line is selected, the entire line will get sent.

I did some quick tests locally and `<leader>r` worked as before in normal mode and sends selected lines (but not the whole buffer) when in a visual mode. I tested with [emlyn/sonic-pi-tool](https://github.com/emlyn/sonic-pi-tool) so you may want to test with [Widdershin/sonic-pi-cli](Widdershin/sonic-pi-cli) (even though I don't expect there to be an issue).

Let me know if README should or shouldn't be changed or if other changes are preferred. Thanks!